### PR TITLE
Remember last selected field group when editing an content object.

### DIFF
--- a/bundle/Resources/public/js/app.js
+++ b/bundle/Resources/public/js/app.js
@@ -89,21 +89,49 @@ $(document).ready(function () {
   /* */
 
   /* edit tabs */
-  (function() {
+  (function(){
     var control = $('.edit-tab-control'),
       trigger = control.find('a'),
       tabs = $('.edit-tabs'),
       tab = tabs.find('.tab'),
-      i = 0;
-    trigger.eq(0).addClass('active');
-    tab.not(tab.eq(0)).hide();
-    trigger.on('click', function(e) {
-      i = $(this).index();
-      trigger.removeClass('active');
-      $(this).addClass('active');
-      tab.eq(i).fadeIn().siblings().hide();
-      e.preventDefault();
-    })
+      groupId = false,
+      preferences = {},
+      preferenceStr = sessionStorage.getItem( 'netgen/ngadminui/preferences' );
+
+    if( preferenceStr )
+    {
+      preferences = JSON.parse( preferenceStr );
+    }
+      groupId = preferences.activeEditTab || false;
+
+      trigger.on('click', function(e){
+        i = $(this).index();
+        trigger.removeClass('active');
+        $(this).addClass('active');
+        tab.eq(i).fadeIn().siblings().hide();
+        sessionStorage.setItem( 'netgen/ngadminui/preferences',
+          JSON.stringify({ activeEditTab: $(this).attr( 'data-field-group' ) })
+        );
+        e.preventDefault();
+      });
+
+      if( groupId )
+      {
+        var selected = trigger.filter( '[data-field-group="'+ groupId +'"]');
+
+        if( selected.length )
+        {
+          selected.click();
+        }
+        else
+        {
+          trigger.eq(0).click();
+        }
+      }
+      else
+      {
+        trigger.eq(0).click();
+      }
   })();
   /* */
 

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/content/edit.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/content/edit.tpl
@@ -111,7 +111,7 @@
                          $attribute_default_category = ezini( 'ClassAttributeSettings', 'DefaultCategory', 'content.ini' )}
 
                 {foreach $content_attributes_grouped_data_map as $attribute_group => $content_attributes_grouped}
-                    <a href="#">{$attribute_categorys[$attribute_group]}</a>
+                    <a href="#" data-field-group="{$attribute_group}">{$attribute_categorys[$attribute_group]}</a>
                 {/foreach}
 
                 {/default}


### PR DESCRIPTION
If you have multiple field groups configured (so not just 'content'). The edit screen for a content object shows them as tabs on the left side of the screen. With this pull request it will remember the last tab you selected and will show that tab after a page load.