### PR TITLE
Replace the template command "ezpagedata_set" and use persistent_variables instead

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/content/view/versionview.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/content/view/versionview.tpl
@@ -10,7 +10,7 @@
 </div>
 {/set-block}
 
-{ezpagedata_set( 'top_menu', $top_menu )}
+{set scope='global' persistent_variable=hash( 'top_menu', $top_menu ) }
 
 <!-- Maincontent START -->
 

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/full.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/full.tpl
@@ -60,7 +60,7 @@
     </div>
 {/set-block}
 
-{ezpagedata_set( 'top_menu', $top_menu )}
+{set scope='global' persistent_variable=hash( 'top_menu', $top_menu ) }
 
 <div class="content-view-full class-{$node.class_identifier}">
     {include uri='design:infocollection_validation.tpl'}


### PR DESCRIPTION
'ezpagedata_set' is defined in another extension (not sure which one - ezwebin maybe?). In any case, we don't use that other extension and therefore we get an error in the admin UI.

I replaced it by using the persistent_variable.