### PR TITLE
Add the Copy button to the full view in the Administration Interface

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_preview_toolbar.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_preview_toolbar.tpl
@@ -32,6 +32,13 @@
                         {else}
                             <li><input class="disabled" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to move this item to another location.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" /></li>
                         {/if}
+                        
+                        {* Copy button. *}
+                        {if $node.object.can_create}
+                            <li><a href={concat("content/copy/",$node.contentobject_id)|ezurl}>{'Copy'|i18n( 'design/admin/node/view/full' )}</a></li>
+                        {else}
+                            <li><a class="disabled" disabled="disabled" href="#">{'Copy'|i18n( 'design/admin/node/view/full' )}</a></li>
+                        {/if}
 
                         {* Remove button. *}
                         {if $node.can_remove}


### PR DESCRIPTION
In the eZ back-end you have Edit / Move / Remove on the page you're viewing

But to copy, you have to initiate it from the "Sub items" window. No more! We will add the Copy button to the full view as well!