### PR TITLE
Set the default tab globally by using a new DefaultTab ini variable

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
@@ -1,8 +1,12 @@
 {* Window controls *}
+{def $default_tab = ezini( 'ViewSettings', 'DefaultTab', 'ngadminui.ini' )}
+{* If no DefaultTab is defined, display view tab by default *}
+{if $default_tab|not()}
+    {set $default_tab = 'view'}
+{/if}
 {def $node_url_alias      = $node.url_alias
      $tabs_disabled       = false()
      $default_tabs        = ezini( 'ViewSettings', 'DefaultTabs', 'ngadminui.ini' )
-     $default_tab         = 'view'
      $node_tab_index      = cond( is_set( $default_tabs[$node.object.class_identifier] ), $default_tabs[$node.object.class_identifier], true(), $default_tab )
      $available_languages = fetch( 'content', 'prioritized_languages' )
      $translations        = $node.object.languages

--- a/bundle/ezpublish_legacy/ngadminui/settings/ngadminui.ini
+++ b/bundle/ezpublish_legacy/ngadminui/settings/ngadminui.ini
@@ -11,6 +11,12 @@ DefaultTabs[ng_gallery]=subitems
 DefaultTabs[folder]=subitems
 DefaultTabs[user_group]=subitems
 
+# (OPTIONAL) Use this setting to set the default tab of the content full view
+# The value must be an string.
+# Possible values are: [view|subitems|translations|locations|relations]
+# DefaultTabs[class_identifier] will override this global setting.
+DefaultTab=subitems
+
 [SnippetEditorSettings]
 # List of content classes where we want to use the editor
 ClassList[]


### PR DESCRIPTION
Hi guys,
I've added the ability to set, in a global way, what tab of a content full view should be displayed through a new ini variable located in the ngadminui.ini file.
![image01](https://user-images.githubusercontent.com/25780820/50493322-ba0e3000-09ea-11e9-9e1c-8ec3ec906cb8.jpg)


Right now the default tab we want to display can be set using the DefaultTabs[] array, but we wanted to show the "subitems" tab no matter what's the object class name.

To do so, I've updated the window_controls template to be able to set the $default_tab variable by reading first the new ini file.
`{def $default_tab = ezini( 'ViewSettings', 'DefaultTab', 'ngadminui.ini' )}`

Looking forward to your feedback,
Thank you!