### PR TITLE
Fixed selected tab with view parameter

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/javascript/node_tabs.js
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/javascript/node_tabs.js
@@ -121,6 +121,6 @@ jQuery(function( $ )
         if($('.tabs').find('.selected').length) {
             selectedId = $('.tabs').find('.selected').attr('id').split('tab-')[1];
         }
-        NodeTab.open( 'node-tab-' + selectedId );
+        NodeTab.open( 'node-tab-' + selectedId, false );
     }
 });

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/javascript/node_tabs.js
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/javascript/node_tabs.js
@@ -121,6 +121,6 @@ jQuery(function( $ )
         if($('.tabs').find('.selected').length) {
             selectedId = $('.tabs').find('.selected').attr('id').split('tab-')[1];
         }
-        NodeTab.open( 'node-tab-' + selectedId, false );
+        NodeTab.open( 'node-tab-' + selectedId );
     }
 });

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
@@ -4,6 +4,7 @@
      $default_tabs        = ezini( 'ViewSettings', 'DefaultTabs', 'ngadminui.ini' )
      $default_tab         = ezini( 'ViewSettings', 'DefaultTab', 'ngadminui.ini' )
      $node_tab_index      = cond( is_set( $default_tabs[$node.object.class_identifier] ), $default_tabs[$node.object.class_identifier], true(), $default_tab )
+     $read_open_tab_by_cookie = true()
      $available_languages = fetch( 'content', 'prioritized_languages' )
      $translations        = $node.object.languages
      $translations_count  = $translations|count
@@ -32,6 +33,14 @@
 
 {set $valid_tabs = $valid_tabs|append( $additional_tabs )
      $additional_tabs_count = $additional_tabs|count()}
+
+{if is_set( $view_parameters.tab )}
+    {* Signal to node_tab.js that tab is forced by url *}
+    {set $read_open_tab_by_cookie = false()}
+    {set $node_tab_index = $view_parameters.tab}
+{elseif $valid_tabs|contains( $node_tab_index )|not()}
+    {set $node_tab_index = $default_tab}
+{/if}
 
 <div class="window-controls-tabs">
     <ul class="tabs clearfix">

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
@@ -4,7 +4,6 @@
      $default_tabs        = ezini( 'ViewSettings', 'DefaultTabs', 'ngadminui.ini' )
      $default_tab         = ezini( 'ViewSettings', 'DefaultTab', 'ngadminui.ini' )
      $node_tab_index      = cond( is_set( $default_tabs[$node.object.class_identifier] ), $default_tabs[$node.object.class_identifier], true(), $default_tab )
-     $read_open_tab_by_cookie = true()
      $available_languages = fetch( 'content', 'prioritized_languages' )
      $translations        = $node.object.languages
      $translations_count  = $translations|count
@@ -36,10 +35,7 @@
 
 {if is_set( $view_parameters.tab )}
     {* Signal to node_tab.js that tab is forced by url *}
-    {set $read_open_tab_by_cookie = false()}
     {set $node_tab_index = $view_parameters.tab}
-{elseif $valid_tabs|contains( $node_tab_index )|not()}
-    {set $node_tab_index = $default_tab}
 {/if}
 
 <div class="window-controls-tabs">


### PR DESCRIPTION
ngadminui got the functionality to set the default tab opened by each content type, however, it lost the possiblity to open a tab via view parameters (.../(tab)/relations). This "fix" restores the previous functionality without touching the new configuration options. 


Please take a look, I need your review on this because I am not fully confident that this is 100% by the book.