### PR TITLE
Add field metadata in the label element title attirbute

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/admin_preview.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/admin_preview.tpl
@@ -14,7 +14,7 @@
                 {if $attribute.display_info.view.grouped_input}
                 <fieldset>
                     <div class="label-preview">
-                        <legend>{$attribute.contentclass_attribute.name|wash}{if $attribute.is_information_collector} <span class="collector">({'information collector'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}</legend>
+                        <legend title="identifier: {$attribute.contentclass_attribute_identifier}, attribute ID: {$attribute.id}, type: {$attribute.data_type_string}, class attribute ID: {$attribute.contentclassattribute_id}">{$attribute.contentclass_attribute.name|wash}{if $attribute.is_information_collector} <span class="collector">({'information collector'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}</legend>
                     </div>
                     <div class="attribute-preview">
                         {attribute_view_gui attribute=$attribute}
@@ -22,7 +22,7 @@
                 </fieldset>
                 {else}
                     <div class="label-preview">
-                        <label>{$attribute.contentclass_attribute.name|wash}{if $attribute.is_information_collector} <span class="collector">({'information collector'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}:</label>
+                        <label title="identifier: {$attribute.contentclass_attribute_identifier}, attribute ID: {$attribute.id}, type: {$attribute.data_type_string}, class attribute ID: {$attribute.contentclassattribute_id}">{$attribute.contentclass_attribute.name|wash}{if $attribute.is_information_collector} <span class="collector">({'information collector'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}:</label>
                     </div>
                     <div class="attribute-preview">
                         {attribute_view_gui attribute=$attribute}


### PR DESCRIPTION
Adds some often needed field metadata to the field label in the content preview:

- FieldDefinition identifier
- Field ID
- FieldType identifier
- FieldDefinition id

The data is available on hover as a tooltip.