### PR TITLE
Add Layouts tab for objects set in media section

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/settings/admininterface.ini.append.php
+++ b/bundle/ezpublish_legacy/ngadminui/settings/admininterface.ini.append.php
@@ -2,11 +2,19 @@
 
 [WindowControlsSettings]
 AdditionalTabs[]=nglayouts
+AdditionalTabs[]=nglayouts_media
 
 [AdditionalTab_nglayouts]
 Title=
 Description=
 NavigationPartName=ezcontentnavigationpart
+HeaderTemplate=nglayouts_header.tpl
+Template=nglayouts.tpl
+
+[AdditionalTab_nglayouts_media]
+Title=
+Description=
+NavigationPartName=ezmedianavigationpart
 HeaderTemplate=nglayouts_header.tpl
 Template=nglayouts.tpl
 */


### PR DESCRIPTION
Useful for objects that have multiple locations (with main location set in media section) in order to see applied layouts to it.