### PR TITLE
Fix media layout tab

### DIFF
--- a/bundle/Resources/views/pagelayout.html.twig
+++ b/bundle/Resources/views/pagelayout.html.twig
@@ -15,7 +15,7 @@
 
     {% include '@NetgenAdminUI/page_head.html.twig' %}
 
-    {% if module_result is defined and navigation_part == 'ezcontentnavigationpart' %}
+    {% if module_result is defined and navigation_part in ['ezcontentnavigationpart', 'ezmedianavigationpart'] %}
         {% include '@NetgenLayoutsAdmin/admin/head.html.twig' ignore missing %}
     {% endif %}
 

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/class/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/class/window_controls.tpl
@@ -23,11 +23,11 @@
 {/if}
 
 {foreach ezini( 'WindowControlsSettings', 'AdditionalTabs', 'admininterface.ini' ) as $tab}
-    {def $tab_navigation_part = ezini( concat( 'AdditionalTab_', $tab ), 'NavigationPartName', 'admininterface.ini' )}
-    {if eq( $tab_navigation_part, $navigation_part_name )}
+    {def $tab_navigation_parts = ezini( concat( 'AdditionalTab_', $tab ), 'NavigationPartName', 'admininterface.ini' )|explode( ';' )}
+    {if $tab_navigation_parts|contains( $navigation_part_name )}
         {set $additional_tabs = $additional_tabs|append( $tab )}
     {/if}
-    {undef $tab_navigation_part}
+    {undef $tab_navigation_parts}
 {/foreach}
 
 {set $valid_tabs = $valid_tabs|append( $additional_tabs )

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
@@ -23,11 +23,11 @@
 {/if}
 
 {foreach ezini( 'WindowControlsSettings', 'AdditionalTabs', 'admininterface.ini' ) as $tab}
-    {def $tab_navigation_part = ezini( concat( 'AdditionalTab_', $tab ), 'NavigationPartName', 'admininterface.ini' )}
-    {if eq( $tab_navigation_part, $navigation_part_name )}
+    {def $tab_navigation_parts = ezini( concat( 'AdditionalTab_', $tab ), 'NavigationPartName', 'admininterface.ini' )|explode( ';' )}
+    {if $tab_navigation_parts|contains( $navigation_part_name )}
         {set $additional_tabs = $additional_tabs|append( $tab )}
     {/if}
-    {undef $tab_navigation_part}
+    {undef $tab_navigation_parts}
 {/foreach}
 
 {set $valid_tabs = $valid_tabs|append( $additional_tabs )

--- a/bundle/ezpublish_legacy/ngadminui/settings/admininterface.ini.append.php
+++ b/bundle/ezpublish_legacy/ngadminui/settings/admininterface.ini.append.php
@@ -2,19 +2,11 @@
 
 [WindowControlsSettings]
 AdditionalTabs[]=nglayouts
-AdditionalTabs[]=nglayouts_media
 
 [AdditionalTab_nglayouts]
 Title=
 Description=
-NavigationPartName=ezcontentnavigationpart
-HeaderTemplate=nglayouts_header.tpl
-Template=nglayouts.tpl
-
-[AdditionalTab_nglayouts_media]
-Title=
-Description=
-NavigationPartName=ezmedianavigationpart
+NavigationPartName=ezcontentnavigationpart;ezmedianavigationpart
 HeaderTemplate=nglayouts_header.tpl
 Template=nglayouts.tpl
 */


### PR DESCRIPTION
This PR fixes the issue introduced in #35 . Layout tab link would appear in the media section, but the tab itself would not load for several reasons:
1. Active state class would not be correctly set to the tab content because the tab container ID was auto-generated by eZ admin and not matching the ID pattern from the tab header
2. The meta tags in pagelayout.html.twig would not load in media section, so the base path for Ajax request was not available
3. Even if we would introduce separate templates and match the ID pattern, the Ajax request for the tab content would not trigger, because the underlying javascript was only triggering on click  on the element with the original tab ID.

With this PR, we introduce different approach: instead of additional duplicate tab for the media section, we allow the NavigationPartName to contain list of navigation parts separated by a semicolon, e.g
`NavigationPartName=ezcontentnavigationpart;ezmedianavigationpart`

