### PR TITLE
ngadminui translation: Add missing i18n calls & translation.ts ger-DE

### DIFF
--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/full.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/node/view/full.tpl
@@ -2,7 +2,7 @@
     <div class="node-top-switch">
         <ul class="node-view-switch">
             <li class="active">
-                <a href=""><i class="fa fa-file-text-o"></i> Content</a>
+                <a href=""><i class="fa fa-file-text-o"></i> {'Content'|i18n( 'design/admin/node/view/full' )}</a>
                 {if fetch( content, translation_list )|count|gt(1)}
                     <form class="dropdown language-switch" method="post" action={'content/action'|ezurl}>
                         {def
@@ -39,7 +39,7 @@
                                     {if $node.object.can_edit_languages|count|gt( 1 )}
                                         <li role="separator" class="divider"></li>
                                     {/if}
-                                    <li><button type="submit" name="EditButton">+ Add new translation</button></li>
+                                    <li><button type="submit" name="EditButton">+ {'Add new translation'|i18n( 'design/admin/node/view/full' )}</button></li>
                                 {/if}
                             </ul>
                         {/if}
@@ -54,7 +54,7 @@
                     <input type="hidden" name="ChangeSettingsButton" value="{'Update view'|i18n( 'design/admin/content/view/versionview' )}" title="{'View the version that is currently being displayed using the selected language, location and design.'|i18n( 'design/admin/content/view/versionview' )}" />
                     <input type="hidden" name="ezxform_token" value="@$ezxFormToken@" />
                 </form>
-                <a type="submit" name="ChangeSettingsButton" title="{'View the version that is currently being displayed using the selected language, location and design.'|i18n( 'design/admin/content/view/versionview' )}" onclick="document.getElementById('previewForm').submit();"><i class="fa fa-globe"></i> Preview</a>
+                <a type="submit" name="ChangeSettingsButton" title="{'View the version that is currently being displayed using the selected language, location and design.'|i18n( 'design/admin/content/view/versionview' )}" onclick="document.getElementById('previewForm').submit();"><i class="fa fa-globe"></i> {'Preview'|i18n( 'design/admin/node/view/full' )}</a>
             </li>
         </ul>
     </div>

--- a/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
+++ b/bundle/ezpublish_legacy/ngadminui/design/ngadminui/templates/window_controls.tpl
@@ -43,31 +43,31 @@
 
         {* Content (pre)view *}
         <li id="node-tab-view" class="first{if $node_tab_index|eq('view')} selected{/if}">
-            <a href={concat( $node_url_alias, '/(tab)/view' )|ezurl} title="{'Show simplified view of content.'|i18n( 'design/admin/node/view/full' )}">Overview</a>
+            <a href={concat( $node_url_alias, '/(tab)/view' )|ezurl} title="{'Show simplified view of content.'|i18n( 'design/admin/node/view/full' )}">{'Overview'|i18n( 'design/admin/node/view/full' )}</a>
         </li>
 
         {* Ordering *}
         <li id="node-tab-subitems" class="{if $additional_tabs}middle{else}last{/if}{if $node_tab_index|eq('subitems')} selected{/if}">
-            <a href={concat( $node_url_alias, '/(tab)/ordering' )|ezurl} title="{'Show subitems.'|i18n( 'design/admin/node/view/full' )}">Sub items {if $node.children_count|gt(0)}<span class="badge">{$node.children_count}</span>{/if}</a>
+            <a href={concat( $node_url_alias, '/(tab)/ordering' )|ezurl} title="{'Show subitems.'|i18n( 'design/admin/node/view/full' )}">{'Sub items'|i18n('design/admin/node/view/full')} {if $node.children_count|gt(0)}<span class="badge">{$node.children_count}</span>{/if}</a>
         </li>
 
         {* Translations *}
         {if fetch( 'content', 'translation_list' )|count|gt( 1 )}
             {if $available_languages|count|gt( 1 ) }
                 <li id="node-tab-translations" class="middle{if $node_tab_index|eq('translations')} selected{/if}">
-                    <a href={concat( $node_url_alias, '/(tab)/translations' )|ezurl} title="{'Show available translations.'|i18n( 'design/admin/node/view/full' )}">Translations {if $translations_count|gt(0)}<span class="badge">{'%count'|i18n( 'design/admin/node/view/full',,hash('%count', $translations_count ) )}</span>{/if}</a>
+                    <a href={concat( $node_url_alias, '/(tab)/translations' )|ezurl} title="{'Show available translations.'|i18n( 'design/admin/node/view/full' )}">{'Translations'|i18n( 'design/admin/node/view/full',,hash('%count', $translations_count ) )} {if $translations_count|gt(0)}<span class="badge">{$translations_count|wash}</span>{/if}</a>
                 </li>
             {/if}
         {/if}
 
         {* Locations *}
         <li id="node-tab-locations" class="middle{if $node_tab_index|eq('locations')} selected{/if}">
-            <a href={concat( $node_url_alias, '/(tab)/locations' )|ezurl} title="{'Show location overview.'|i18n( 'design/admin/node/view/full' )}">Locations {if $node.object.assigned_nodes|count|gt(0)}<span class="badge">{'%count'|i18n( 'design/admin/node/view/full',, hash( '%count', $node.object.assigned_nodes|count ) )}</span>{/if}</a>
+            <a href={concat( $node_url_alias, '/(tab)/locations' )|ezurl} title="{'Show location overview.'|i18n( 'design/admin/node/view/full' )}">{'Locations'|i18n( 'design/admin/node/view/full',, hash( '%count', $node.object.assigned_nodes|count ) )} {if $node.object.assigned_nodes|count|gt(0)}<span class="badge">{$node.object.assigned_nodes|count}</span>{/if}</a>
         </li>
 
         {* Relations *}
         <li id="node-tab-relations" class="middle{if $node_tab_index|eq('relations')} selected{/if}">
-            <a href={concat( $node_url_alias, '/(tab)/relations' )|ezurl} title="{'Show object relation overview.'|i18n( 'design/admin/node/view/full' )}">Relations {if $reverse_related_objects_count|gt(0)}<span class="badge">{'%count'|i18n( 'design/admin/node/view/full',, hash( '%count', sum( $related_objects_count, $reverse_related_objects_count ) ) )}</span>{/if}</a>
+            <a href={concat( $node_url_alias, '/(tab)/relations' )|ezurl} title="{'Show object relation overview.'|i18n( 'design/admin/node/view/full' )}">{'Relations'|i18n( 'design/admin/node/view/full',, hash( '%count', sum( $related_objects_count, $reverse_related_objects_count ) ) )} {if $reverse_related_objects_count|gt(0)}<span class="badge">{sum( $related_objects_count, $reverse_related_objects_count)}</span>{/if}</a>
         </li>
 
         {include uri='design:window_controls_extratabs.tpl'}

--- a/bundle/ezpublish_legacy/ngadminui/settings/site.ini.append.php
+++ b/bundle/ezpublish_legacy/ngadminui/settings/site.ini.append.php
@@ -2,4 +2,8 @@
 
 [TemplateSettings]
 ExtensionAutoloadPath[]=ngadminui
+
+[RegionalSettings]
+TranslationExtensions[]=ngadminui
+
 */ ?>

--- a/bundle/ezpublish_legacy/ngadminui/translations/ger-DE/translation.ts
+++ b/bundle/ezpublish_legacy/ngadminui/translations/ger-DE/translation.ts
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS><TS version="1.1" language="de_DE">
+<defaultcodec></defaultcodec>
+<context>
+    <name>design/admin/node/view/full</name>
+        <message>
+            <source>Use these controls to sort the sub items of the current location on frontend:</source>
+            <translation>Verwenden Sie diese Steuerelemente, um die Unterelemente des aktuellen Ortes im Frontend zu sortieren:</translation>
+        </message>
+        <message>
+            <source>Content</source>
+            <translation>Inhalt</translation>
+        </message>
+        <message>
+            <source>Overview</source>
+            <translation>Übersicht</translation>
+        </message>
+        <message>
+            <source>Create new subitem</source>
+            <translation>Neues Unterelement anlegen</translation>
+        </message>
+        <message>
+            <source>Add new translation</source>
+            <translation>Neue Übersetzung hinzufügen</translation>
+        </message>
+    </context>
+    <context>
+    <name>design/admin/content/history</name>
+        <message>
+            <source>Versions for &lt; %object_name &gt; (%version_count)</source>
+            <translation>Versionen von &lt; %object_name &gt; (%version_count)</translation>
+        </message>
+    </context>
+
+
+
+</TS>

--- a/bundle/ezpublish_legacy/ngadminui/translations/untranslated/translation.ts
+++ b/bundle/ezpublish_legacy/ngadminui/translations/untranslated/translation.ts
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS>
+    <context>
+        <name>design/admin/node/view/full</name>
+        <message>
+            <source>Use these controls to sort the sub items of the current location on frontend:</source>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <source>Content</source>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <source>Overview</source>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <source>Create new subitem</source>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <source>Add new translation</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+
+    <context>
+        <name>design/admin/content/history</name>
+        <message>
+            <source>Versions for &lt; %object_name &gt; (%version_count)</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+
+
+
+</TS>


### PR DESCRIPTION
add Missing i18n calls to be able to translate the content full view of ngadminui
and adding a translation.js for ger-DE 
and define the legacy extension ngadminui as translation extension