### PR TITLE
NGSTACK-987 add slash between api url and ngadmin if needed

### DIFF
--- a/bundle/Resources/public/js/app.js
+++ b/bundle/Resources/public/js/app.js
@@ -630,7 +630,8 @@ $(document).ready(function () {
     const locationId = document.querySelector('.mapped-layouts-box').dataset.url.split('/').pop();
     const basePath = document.querySelector('[name="ngadminui-base-path"]').getAttribute('content');
     const apiUrl = `${window.location.origin}${basePath}`;
-    const baseUrl = `${apiUrl}ngadmin/layouts`;
+    const slash = apiUrl.endsWith('/') ? '' : '/';
+    const baseUrl = `${apiUrl}${slash}ngadmin/layouts`;
     const url = `${baseUrl}/${locationId}/wizard`;
     const modal = new NlModal({
       preload: true,


### PR DESCRIPTION
Fix error when clicking the “New layout” button, a slash is missing in the wizard url.

For example, the url is `/ngadminuingadmin/layouts/{id}/wizard` and should be `/ngadminui/ngadmin/layouts/{id}/wizard`.